### PR TITLE
GPU support on Apple Silicon

### DIFF
--- a/manga_ocr/ocr.py
+++ b/manga_ocr/ocr.py
@@ -18,6 +18,9 @@ class MangaOcr:
         if not force_cpu and torch.cuda.is_available():
             logger.info('Using CUDA')
             self.model.cuda()
+        if not force_cpu and torch.backends.mps.is_available():
+            logger.info('Using MPS')
+            self.model.to('mps')
         else:
             logger.info('Using CPU')
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ loguru
 numpy
 Pillow
 pyperclip
-torch>=1.0
+torch
 transformers>=4.12.5
 sentencepiece
 unidic_lite

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ loguru
 numpy
 Pillow
 pyperclip
-torch
+torch>=2.0.0
 transformers>=4.12.5
 sentencepiece
 unidic_lite

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,4 @@ Pillow
 pyperclip
 torch>=1.0
 transformers>=4.25.0
-sentencepiece
 unidic_lite


### PR DESCRIPTION
Requires PyTorch 2.0.0 and MacOS 13.3, since lower version of MacOS does not natively support some operations with int64 input (see: https://github.com/pytorch/pytorch/pull/95817).