### PR TITLE
Add support for Linux clipboard reading

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ See also:
 
 # Installation
 
-You need Python 3.6, 3.7, 3.8 or 3.9. Unfortunately, PyTorch does not support Python 3.10 yet.
+You need Python 3.8, 3.9, 3.10 or 3.11.
 
 If you want to run with GPU, install PyTorch as described [here](https://pytorch.org/get-started/locally/#start-locally),
 otherwise this step can be skipped.
@@ -69,7 +69,6 @@ Manga OCR can run in the background and process new images as they appear.
 You might use a tool like [ShareX](https://getsharex.com/) to manually capture a region of the screen and let the
 OCR read it either from the system clipboard, or a specified directory. By default, Manga OCR will write recognized text to clipboard,
 from which it can be read by a dictionary like [Yomichan](https://github.com/FooSoft/yomichan).
-Reading images from clipboard works only on Windows and macOS, on Linux you should read from a directory instead.
 
 Your full setup for reading manga in Japanese with a dictionary might look like this:
 

--- a/README.md
+++ b/README.md
@@ -66,9 +66,11 @@ text = mocr(img)
 
 Manga OCR can run in the background and process new images as they appear.
 
-You might use a tool like [ShareX](https://getsharex.com/) to manually capture a region of the screen and let the
+You might use a tool like [ShareX](https://getsharex.com/) or [Flameshot](https://flameshot.org/) to manually capture a region of the screen and let the
 OCR read it either from the system clipboard, or a specified directory. By default, Manga OCR will write recognized text to clipboard,
 from which it can be read by a dictionary like [Yomichan](https://github.com/FooSoft/yomichan).
+
+Clipboard mode on Linux requires `wl-copy` for Wayland sessions or `xclip` for X11 sessions. You can find out which one your system needs by running `echo $XDG_SESSION_TYPE` in the terminal.
 
 Your full setup for reading manga in Japanese with a dictionary might look like this:
 

--- a/manga_ocr/ocr.py
+++ b/manga_ocr/ocr.py
@@ -18,7 +18,7 @@ class MangaOcr:
         if not force_cpu and torch.cuda.is_available():
             logger.info('Using CUDA')
             self.model.cuda()
-        if not force_cpu and torch.backends.mps.is_available():
+        elif not force_cpu and torch.backends.mps.is_available():
             logger.info('Using MPS')
             self.model.to('mps')
         else:

--- a/manga_ocr/run.py
+++ b/manga_ocr/run.py
@@ -65,6 +65,18 @@ def run(read_from='clipboard',
 
     mocr = MangaOcr(pretrained_model_name_or_path, force_cpu)
 
+    if sys.platform not in ('darwin', 'win32') and write_to == 'clipboard':
+        # Check if the system is using Wayland
+        import os
+        if os.environ.get('WAYLAND_DISPLAY'):
+            # Check if the wl-clipboard package is installed
+            if os.system("which wl-copy > /dev/null") == 0:
+                pyperclip.set_clipboard("wl-clipboard")
+            else:
+                msg = 'Your session uses wayland and does not have wl-clipboard installed. ' \
+                    'Install wl-clipboard for write in clipboard to work.'
+                raise NotImplementedError(msg)
+
     if read_from == 'clipboard':
         from PIL import ImageGrab
         logger.info('Reading from clipboard')

--- a/manga_ocr/run.py
+++ b/manga_ocr/run.py
@@ -48,7 +48,8 @@ def run(read_from='clipboard',
         write_to='clipboard',
         pretrained_model_name_or_path='kha-white/manga-ocr-base',
         force_cpu=False,
-        delay_secs=0.1
+        delay_secs=0.1,
+        verbose=False
         ):
     """
     Run OCR in the background, waiting for new images to appear either in system clipboard, or a directory.
@@ -58,6 +59,7 @@ def run(read_from='clipboard',
     :param write_to: Specifies where to save recognized texts to. Can be either "clipboard", or a path to a text file.
     :param pretrained_model_name_or_path: Path to a trained model, either local or from Transformers' model hub.
     :param force_cpu: If True, OCR will use CPU even if GPU is available.
+    :param verbose: If True, unhides all warnings.
     :param delay_secs: How often to check for new images, in seconds.
     """
 
@@ -74,10 +76,10 @@ def run(read_from='clipboard',
             try:
                 img = ImageGrab.grabclipboard()
             except OSError as error:
-                if "cannot identify image file" in str(error):
+                if not verbose and "cannot identify image file" in str(error):
                     # Pillow error when clipboard hasn't changed since last grab (Linux)
                     pass
-                elif "target image/png not available" in str(error):
+                elif not verbose and "target image/png not available" in str(error):
                     # Pillow error when clipboard contains text (Linux, X11)
                     pass
                 else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ fugashi
 jaconv
 loguru
 numpy
-Pillow
+Pillow>=10.0.0
 pyperclip
 torch>=1.0
 transformers>=4.25.0


### PR DESCRIPTION
Pillow 10.0.0 fixed [the last outstanding issue with grabclipboard on Linux X11](https://github.com/python-pillow/Pillow/pull/7112) so we can now use it for grabbing the clipboard on all OSs and session types.

Summary:

- Remove code path that blocks Linux clipboard mode, now use Pillow for all OS types
- Add suppression of unnecessary Pillow errors (--verbose to show them again)
- Minimum python version changed to 3.8 due to Pillow upgrade, 3.6 and 3.7 are unsupported now anyway
- Maximum python version changed to 3.11 since PyTorch 2 supports it and manga-ocr runs perfectly under it