### PR TITLE
Added cli mode

### DIFF
--- a/manga_ocr/run.py
+++ b/manga_ocr/run.py
@@ -31,10 +31,12 @@ def process_and_write_results(mocr, img_or_path, write_to):
 
     if write_to == 'clipboard':
         pyperclip.copy(text)
+    elif write_to == 'cli':
+        print(text)
     else:
         write_to = Path(write_to)
         if write_to.suffix != '.txt':
-            raise ValueError('write_to must be either "clipboard" or a path to a text file')
+            raise ValueError('write_to must be either "clipboard", "cli" or a path to a text file')
 
         with write_to.open('a', encoding="utf-8") as f:
             f.write(text + '\n')
@@ -101,11 +103,26 @@ def run(read_from='clipboard',
                     process_and_write_results(mocr, img, write_to)
 
             time.sleep(delay_secs)
+    elif read_from == 'cli':
+        logger.info(f'Reading from cli')
 
+        while True:
+            path = input('Enter image path:\n')
+            read_from = Path(path)
+            if not read_from.is_file():
+                print(f'{path} is not a file')
+                continue
+            try:
+                img = Image.open(read_from)
+                img.load()
+            except (UnidentifiedImageError, OSError) as e:
+                print(f'Error while reading file {path}: {e}')
+            else:
+                process_and_write_results(mocr, img, write_to)
     else:
         read_from = Path(read_from)
         if not read_from.is_dir():
-            raise ValueError('read_from must be either "clipboard" or a path to a directory')
+            raise ValueError('read_from must be either "clipboard", "cli" or a path to a directory')
 
         logger.info(f'Reading from directory {read_from}')
 


### PR DESCRIPTION
I added a cli mode for both input and output. In cli mode manga-ocr continuously requests a path to an image and returns the ocr result in the console. 
I added it so that i could use manga-ocr from a different program without having to read results from a textfile. Also in my use case reading images from a folder did not work since the images i am working with are saved in a temp folder. 