### PR TITLE
Relax numpy constraint to allow numpy 2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "fugashi",
     "jaconv",
     "loguru",
-    "numpy<2",
+    "numpy",
     "Pillow>=10.0.0",
     "pyperclip",
     "torch>=1.0",


### PR DESCRIPTION
We don't have a version constraint for various other dependencies, and having this constraint causes a build failure in the nixpkgs build of this package: https://github.com/NixOS/nixpkgs/issues/369935

After removing this constraint, we get numpy2, and the program still runs and OCRs stuff, so it seems like it works fine?

Happy to test anything else too of course if there's any specific worries about something numpy2 might break