### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,13 +67,13 @@ Manga OCR can run in the background and process new images as they appear.
 
 You might use a tool like [ShareX](https://getsharex.com/) or [Flameshot](https://flameshot.org/) to manually capture a region of the screen and let the
 OCR read it either from the system clipboard, or a specified directory. By default, Manga OCR will write recognized text to clipboard,
-from which it can be read by a dictionary like [Yomichan](https://github.com/FooSoft/yomichan).
+from which it can be read by a dictionary like [Yomitan](https://github.com/yomidevs/yomitan).
 
 Clipboard mode on Linux requires `wl-copy` for Wayland sessions or `xclip` for X11 sessions. You can find out which one your system needs by running `echo $XDG_SESSION_TYPE` in the terminal.
 
 Your full setup for reading manga in Japanese with a dictionary might look like this:
 
-capture region with ShareX -> write image to clipboard -> Manga OCR -> write text to clipboard -> Yomichan
+capture region with ShareX -> write image to clipboard -> Manga OCR -> write text to clipboard -> Yomitan
 
 https://user-images.githubusercontent.com/22717958/150238361-052b95d1-0152-485f-a441-48a957536239.mp4
 


### PR DESCRIPTION
Yomichan is no longer maintained, and a new fork named Yomitan has been developed to address its unresolved bugs and support the Manifest V3 transition. It’s recommended to switch to Yomitan for continued functionality and improvements. The demo video may need to be updated as well to use Yomitan instead, but I'll leave that to you.