### PR TITLE
feat(cli): add clipboard-based OCR monitor example using MangaOCR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,6 +112,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+.hf-cache
 
 # Spyder project settings
 .spyderproject

--- a/manga_ocr_monitor/default.nix
+++ b/manga_ocr_monitor/default.nix
@@ -1,0 +1,37 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+let
+  python = pkgs.python312;
+in
+pkgs.python312Packages.buildPythonApplication {
+  pname = "manga-ocr-monitor";
+  version = "0.1.0";
+
+  src = ./.;
+
+  pyproject = true;
+  build-system = with pkgs.python312Packages; [ setuptools ];
+
+  dontWrapPythonPrograms = false;
+  dontUsePythonReexec = true;
+
+  propagatedBuildInputs = with python.pkgs; [
+    pillow
+    numpy
+    torch
+    torchvision
+    transformers
+    sentencepiece
+    jaconv
+    fugashi
+    mecab-python3
+    unidic-lite
+    loguru
+    manga-ocr
+  ] ++ [
+    pkgs.wl-clipboard
+    pkgs.xclip
+  ];
+
+  doCheck = false;
+}

--- a/manga_ocr_monitor/flake.lock
+++ b/manga_ocr_monitor/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1765186076,
+        "narHash": "sha256-hM20uyap1a0M9d344I692r+ik4gTMyj60cQWO+hAYP8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "addf7cf5f383a3101ecfba091b98d0a1263dc9b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/manga_ocr_monitor/flake.nix
+++ b/manga_ocr_monitor/flake.nix
@@ -1,0 +1,49 @@
+{
+  description = "Japanese OCR clipboard monitor";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        python = pkgs.python312;
+      in {
+        packages.default = python.pkgs.buildPythonApplication {
+          pname = "manag-ocr-monitor";
+          version = "0.1.0";
+          src = self;
+
+          pyproject = true;
+          build-system = with python.pkgs; [ setuptools ];
+
+          propagatedBuildInputs = with python.pkgs; [
+            pillow
+            numpy
+            torch
+            torchvision
+            transformers
+            sentencepiece
+            jaconv
+            fugashi
+            mecab-python3
+            unidic-lite
+            loguru
+            manga-ocr
+          ] ++ [
+            pkgs.wl-clipboard
+            pkgs.xclip
+          ];
+
+          doCheck = false;
+        };
+
+        apps.default = {
+          type = "app";
+          program = "${self.packages.${system}.default}/bin/manga-ocr-monitor";
+        };
+      });
+}

--- a/manga_ocr_monitor/jp_ocr_monitor/ocr.py
+++ b/manga_ocr_monitor/jp_ocr_monitor/ocr.py
@@ -1,0 +1,205 @@
+import os
+import subprocess
+import time
+import hashlib
+from io import BytesIO
+from PIL import Image
+from manga_ocr import MangaOcr
+import signal
+import sys
+
+
+from transformers import logging 
+logging.set_verbosity_error()
+
+
+_stop = False
+
+def _handle_sigint(sig, frame):
+    global _stop
+    _stop = True
+
+signal.signal(signal.SIGINT, _handle_sigint)
+signal.signal(signal.SIGTERM, _handle_sigint)
+
+
+def env():
+    return {
+        "session": os.environ.get("XDG_SESSION_TYPE", "").lower(),
+        "desktop": os.environ.get("XDG_CURRENT_DESKTOP", "").lower(),
+    }
+
+
+def has(cmd):
+    return subprocess.call(
+        ["which", cmd],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL
+    ) == 0
+
+
+def require(cmd, msg):
+    if not has(cmd):
+        raise RuntimeError(msg)
+
+
+# ------------------------
+# WAYLAND - GNOME (poll)
+# ------------------------
+
+def wayland_poll(mocr):
+    print("Wayland GNOME → polling mode")
+
+    last_hash = None
+
+    while not _stop:
+        types = subprocess.run(
+            ["wl-paste", "-l"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True
+        ).stdout
+
+        if "image/png" not in types:
+            time.sleep(0.5)
+            continue
+
+        data = subprocess.run(
+            ["wl-paste", "--type", "image/png"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL
+        ).stdout
+
+        if not data:
+            time.sleep(0.5)
+            continue
+
+        h = hashlib.md5(data).hexdigest()
+        if h == last_hash:
+            time.sleep(1.5)
+            continue
+
+        last_hash = h
+        img = Image.open(BytesIO(data))
+        text = mocr(img)
+        print(text)
+
+        subprocess.run(["wl-copy"], input=text.encode(), check=False)
+
+    print("Exiting…")
+
+
+# ------------------------
+# WAYLAND - EVENT DRIVEN
+# ------------------------
+
+def wayland_watch(mocr):
+    print("Wayland compositor → event-driven")
+
+    proc = subprocess.Popen(
+        ["wl-paste", "--watch", "--type", "image/png", "cat"],
+        stdout=subprocess.PIPE
+    )
+
+    last_hash = None
+
+    try:
+        while not _stop:
+            data = proc.stdout.readline()
+            if not data:
+                continue
+
+            h = hashlib.md5(data).hexdigest()
+            if h == last_hash:
+                continue
+
+            last_hash = h
+            img = Image.open(BytesIO(data))
+            text = mocr(img)
+            print(text)
+
+            subprocess.run(["wl-copy"], input=text.encode(), check=False)
+
+    finally:
+        proc.terminate()
+        proc.wait()
+        print("Exiting…")
+
+
+# ------------------------
+# X11
+# ------------------------
+
+def x11_watch(mocr):
+    print("X11 → event-driven")
+
+    if has("xclip"):
+        get = ["xclip", "-selection", "clipboard", "-t", "image/png", "-o"]
+        set_ = ["xclip", "-selection", "clipboard"]
+    elif has("xsel"):
+        get = ["xsel", "--clipboard", "--output"]
+        set_ = ["xsel", "--clipboard", "--input"]
+    else:
+        raise RuntimeError("xclip or xsel required on X11")
+
+    last_hash = None
+
+    while not _stop:
+        try:
+            data = subprocess.check_output(get, stderr=subprocess.DEVNULL)
+        except subprocess.CalledProcessError:
+            time.sleep(0.5)
+            continue
+
+        if not data:
+            time.sleep(0.5)
+            continue
+
+        h = hashlib.md5(data).hexdigest()
+        if h == last_hash:
+            time.sleep(1.5)
+            continue
+
+        last_hash = h
+        img = Image.open(BytesIO(data))
+        text = mocr(img)
+        print(text)
+
+        subprocess.run(set_, input=text.encode(), check=False)
+
+    print("Exiting…")
+
+
+# ------------------------
+# MAIN
+# ------------------------
+
+def main():
+    try:
+        e = env()
+
+        if e["session"] == "wayland":
+            require("wl-paste", "wl-clipboard not available")
+            require("wl-copy", "wl-clipboard not available")
+        elif e["session"] == "x11":
+            if not (has("xclip") or has("xsel")):
+                raise RuntimeError("xclip or xsel required on X11")
+
+        mocr = MangaOcr()
+        print("CTRL+C to exit")
+
+        if e["session"] == "wayland":
+            if "gnome" in e["desktop"]:
+                wayland_poll(mocr)
+            else:
+                wayland_watch(mocr)
+        elif e["session"] == "x11":
+            x11_watch(mocr)
+
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":
+    main()
+

--- a/manga_ocr_monitor/pyproject.toml
+++ b/manga_ocr_monitor/pyproject.toml
@@ -1,0 +1,17 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "jp-ocr-monitor"
+version = "0.1.0"
+description = "Clipboard OCR monitor for manga images"
+requires-python = ">=3.10"
+
+[project.scripts]
+manga-ocr-monitor = "jp_ocr_monitor.ocr:main"
+
+[tool.setuptools.packages.find]
+where = ["."]
+
+# Runtime Dependencies uses Nix propagatedBuildInputs

--- a/manga_ocr_monitor/shell.nix
+++ b/manga_ocr_monitor/shell.nix
@@ -1,0 +1,74 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+let
+  python = pkgs.python312;
+
+  manga-ocr = python.pkgs.buildPythonPackage rec {
+    pname = "manga-ocr";
+    version = "0.1.11";
+
+    src = python.pkgs.fetchPypi {
+      inherit pname version;
+      sha256 = "sha256-Ic6AaSaEY1NaPHgF9xawj1gmrwWqf1NhmTs8NYKZsOs=";
+    };
+
+    postPatch = ''
+      sed -i \
+        's/self(example_path)/if example_path.exists(): self(example_path)/' \
+        manga_ocr/ocr.py
+    '';
+
+    propagatedBuildInputs = with python.pkgs; [
+      pillow
+      numpy
+      torch
+      torchvision
+      transformers
+      sentencepiece
+      jaconv
+      loguru
+      fugashi
+      mecab-python3
+      unidic-lite
+    ];
+
+    doCheck = false;
+  };
+
+in
+pkgs.mkShell {
+  packages = [
+    (python.withPackages (ps: with ps; [
+      pillow
+      numpy
+      torch
+      torchvision
+      transformers
+      sentencepiece
+      manga-ocr
+    ]))
+
+    # Wayland
+    pkgs.wl-clipboard
+
+    # X11
+    pkgs.xclip
+
+    # Graphcs libs
+    pkgs.libGL
+    pkgs.mesa
+    pkgs.libjpeg
+    pkgs.libpng
+    pkgs.freetype
+    pkgs.zlib
+    pkgs.libffi
+    pkgs.pkg-config
+  ];
+
+  shellHook = ''
+    export HF_HOME=$PWD/.hf-cache
+    export LD_LIBRARY_PATH=/run/opengl-driver/lib:$LD_LIBRARY_PATH
+    echo "MangaOCR ready (Wayland + X11)"
+  '';
+}
+


### PR DESCRIPTION
Add a CLI example that monitors the system clipboard for images and runs MangaOCR automatically when new content is detected.

- Supports Wayland (GNOME polling + event-driven compositors)
- Supports X11 via xclip/xsel
- Automatic environment detection (Wayland vs X11)
- Graceful Ctrl+C handling
- Fully packaged with Nix (flake-based) as a reproducible example

This is intended as a reference implementation for users who want to experiment with MangaOCR outside notebooks or scripts.