### PR TITLE
add support for listening on unix socket

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,13 @@ The OCR is ready to use after `OCR ready` message appears in the logs.
 
 If `manga_ocr` doesn't work, you might also try replacing it with `python -m manga_ocr`.
 
+### Unix domain socket mode
+
+On Linux, if Manga OCR is launched with a path that begins with `@`, Manga OCR will listen for connections on that Unix domain socket path. A client is expected to connect, send a file in a normal image format, signal end-of-file, and then receive the OCR'd text. You can then connect to Manga OCR from a shell script like this (where `grim -g "$(slurp)" -` is used on Wayland to grab a screenshot of a user-selected screen region):
+```sh
+echo "OCR result: $(grim -g "$(slurp)" - | nc -NU /tmp/ocr.sock)"
+```
+
 ## Usage tips
 
 - OCR supports multi-line text, but the longer the text, the more likely some errors are to occur.

--- a/manga_ocr/run.py
+++ b/manga_ocr/run.py
@@ -1,3 +1,5 @@
+import io
+import socket
 import sys
 import time
 from pathlib import Path
@@ -106,7 +108,33 @@ def run(
                     process_and_write_results(mocr, img, write_to)
 
             time.sleep(delay_secs)
+    elif read_from[0] == '@':
+        # remove existing socket, if it exists - bind() fails if one already exists
+        try:
+            os.unlink(read_from[1:])
+        except FileNotFoundError as e:
+            pass
 
+        ssock = socket.socket(family=socket.AF_UNIX, type=socket.SOCK_STREAM)
+        ssock.bind(read_from[1:])
+        ssock.listen(1)
+        while True:
+            (sock, _) = ssock.accept()
+            data_in = sock.recv(1024*1024*32, socket.MSG_WAITALL)
+
+            try:
+                img = Image.open(io.BytesIO(data_in))
+                img.load()
+            except (UnidentifiedImageError, OSError) as e:
+                logger.warning(f"Error while reading file from socket message: {e}")
+            else:
+                t0 = time.time()
+                text = mocr(img)
+                t1 = time.time()
+                logger.info(f"Text recognized in {t1 - t0:0.03f} s: {text}")
+
+            sock.sendall(bytes(text, 'utf-8'))
+            sock.close()
     else:
         read_from = Path(read_from)
         if not read_from.is_dir():


### PR DESCRIPTION
This adds support for listening on a unix domain socket, so that you can have Manga OCR run as a background service and easily process images with it from scripts that, for example, let the user select a region, grab a screenshot of that region, OCR the screenshot, and then feed the result into a dictionary.